### PR TITLE
[perf] Profiling and Performance improvement for get_sigmoid_faetures_dev 

### DIFF
--- a/actsnfink/classifier_sigmoid.py
+++ b/actsnfink/classifier_sigmoid.py
@@ -22,6 +22,7 @@ from actsnfink.sigmoid import fit_sigmoid
 from actsnfink.sigmoid import delta_t
 from actsnfink.sigmoid import compute_mse
 from actsnfink.sigmoid import fsigmoid
+from line_profile import profile
 
 __all__ = ['filter_data', 'mask_negative_data', 'get_fake_df', 'get_fake_fit_parameters',
           'get_fake_results', 'get_ewma_derivative', 'get_sn_ratio', 'get_predicted_flux',
@@ -341,7 +342,7 @@ def get_max_fluxcal(data, list_filters):
 
     return max_fluxcal
 
-
+@profile
 def get_sigmoid_features_dev(data_all: pd.DataFrame, ewma_window=3, 
                              min_rising_points=2, min_data_points=4,
                              rising_criteria='ewma'):
@@ -447,6 +448,133 @@ def get_sigmoid_features_dev(data_all: pd.DataFrame, ewma_window=3,
         a['r'], b['r'], c['r'], snratio['r'], mse['r'], nrise['r']
     ]
 
+@profile
+def get_sigmoid_features_dev_fast(data_all: pd.DataFrame, ewma_window=3, 
+                             min_rising_points=2, min_data_points=4,
+                             rising_criteria='ewma'):
+    """Compute the features needed for the Random Forest classification based
+    on the sigmoid model.
+
+    Parameters
+    ----------
+    data_all: pd.DataFrame
+        Pandas DataFrame with at least ['MJD', 'FLT', 'FLUXCAL', 'FLUXCALERR']
+        as columns.
+    ewma_window: int (optional)
+        Width of the ewma window. Default is 3.
+    min_rising_points: int (optional)
+        Minimum number of rising points. Default is 2.
+    min_data_points: int (optional)
+        Minimum number of data points. Default is 4.
+    rising_criteria: str (optional)
+        Criteria for defining rising points. Options are 'diff' or 'ewma'.
+        Default is 'ewma'.
+
+    Returns
+    -------
+    out: list of floats
+        List of features, ordered by filter bands:
+        [a['g'], b['g'], c['g'], snratio['g'], mse['g'], nrise['g'],
+         a['r'], b['r'], c['r'], snratio['r'], mse['r'], nrise['r']]
+
+    """
+    # lower bound on flux
+    low_bound = -10
+
+    list_filters = ['g', 'r']
+
+    # features for different filters
+    a = {}
+    b = {}
+    c = {}
+    snratio = {}
+    mse = {}
+    nrise = {}
+
+    # avoid deepcopy (slow), replace it by numpy+mask 
+    data_np = data_all[columns_to_keep].to_numpy()
+    # extract columns on format numpy
+    mjd_all, flt_all, flux_all, flux_err_all = data_np[:,0:4].T
+    # ensure right type
+    mjd_all = mjd_all.astype(float)
+    flux_all = flux_all.astype(float)
+    flux_err_all = flux_err_all.astype(float)
+    for i in list_filters:
+        # add mask to filter
+        mask_flt = flt_all == i
+        mjd = mjd_all[mask_flt]
+        flux = flux_all[mask_flt]
+        flux_err = flux_err_all[mask_flt]
+
+        # vectorised average over intraday data points 
+
+        mjd_round = np.round(mjd).astype(int) 
+        unique_mjd = np.unique(mjd_round)
+        #Sum flux per unique mjd
+        flux_sum = np.bincount(mjd_round, weights=flux)
+        flux_count = np.bincount(mjd_round)
+        flux_avg = flux_sum[unique_mjd] / flux_count[unique_mjd]
+        # the same for err
+        flux_err_sum = np.bincount(mjd_round, weights=flux_err)
+        flux_err_avg = flux_err_sum[unique_mjd] / flux_count[unique_mjd]
+        
+        mjd_avg = unique_mjd
+
+        # mask negative flux below low bound
+        valid = flux_avg > low_bound
+        flux_avg = flux_avg[valid]
+        flux_err_avg = flux_err_avg[valid]
+        mjd_avg = mjd_avg[valid]
+
+        # check minimum number of points per filter
+        if len(flux_avg) >= min_data_points:
+
+            if rising_criteria == 'ewma':
+                # compute the derivative
+                rising_c = get_ewma_derivative(pd.Series(flux_avg), ewma_window)
+            elif rising_criteria == 'diff':
+                # calculate the diff with np (vectorized)
+                rising_c = np.diff(flux_avg,prepend=flux_avg[0])
+                      
+            # mask data with negative derivative
+            mask_rising = rising_c >= 0 
+            flux_rising = flux_avg[mask_rising]
+            flux_err_rising = flux_err_avg[mask_rising]
+            mjd_rising = mjd_avg[mask_rising]
+            # at least three points (needed for the sigmoid fit) and all points on the rise
+            if(len(flux_rising) >= min_rising_points) and len(flux_rising) == len(flux_avg):
+
+                # compute signal to noise ratio
+                snratio[i] = get_sn_ratio(flux_rising,flux_err_rising)
+
+                # get N rising points
+                nrise[i] = len(flux_rising)
+
+                dt = delta_t(mjd_rising)
+
+                # perform sigmoid fit
+                [a[i], b[i], c[i]] = fit_sigmoid(dt,flux_rising)
+
+                # predicted flux with fit parameters
+                pred_flux = get_predicted_flux(dt, a[i], b[i], c[i])
+
+                # compute mse
+                mse[i] = compute_mse(flux_rising/sum(flux_rising),
+                                     pred_flux/sum(pred_flux))
+
+            else:
+                # if rising flux has less than three
+                [a[i], b[i], c[i], snratio[i], mse[i], nrise[i]] = \
+                    get_fake_results(i)
+        else:
+            # if data points not enough
+            [a[i], b[i], c[i], snratio[i], mse[i], nrise[i]] = \
+                get_fake_results(i)
+
+    return [
+        a['g'], b['g'], c['g'], snratio['g'], mse['g'], nrise['g'],
+        a['r'], b['r'], c['r'], snratio['r'], mse['r'], nrise['r']
+    ]
 
 def main():
     return None

--- a/actsnfink/classifier_sigmoid.py
+++ b/actsnfink/classifier_sigmoid.py
@@ -449,7 +449,7 @@ def get_sigmoid_features_dev(data_all: pd.DataFrame, ewma_window=3,
     ]
 
 @profile
-def get_sigmoid_features_dev_fast(data_all: pd.DataFrame, ewma_window=3, 
+def get_sigmoid_features_dev_fast(data_all: pd.DataFrame, ewma_window=3,  
                              min_rising_points=2, min_data_points=4,
                              rising_criteria='ewma'):
     """Compute the features needed for the Random Forest classification based
@@ -491,7 +491,7 @@ def get_sigmoid_features_dev_fast(data_all: pd.DataFrame, ewma_window=3,
     mse = {}
     nrise = {}
 
-    # avoid deepcopy (slow), replace it by numpy+mask 
+    # avoid deepcopy (slow), replace it by numpy+mask
     data_np = data_all[columns_to_keep].to_numpy()
     # extract columns on format numpy
     mjd_all, flt_all, flux_all, flux_err_all = data_np[:,0:4].T
@@ -506,26 +506,29 @@ def get_sigmoid_features_dev_fast(data_all: pd.DataFrame, ewma_window=3,
         flux = flux_all[mask_flt]
         flux_err = flux_err_all[mask_flt]
 
-        # vectorised average over intraday data points 
+        # vectorised average over intraday data points
+        mjd_round = np.around(mjd,decimals=0).astype(int)
+        unique_mjd, inv = np.unique(mjd_round, return_inverse=True)
+        valid_flux = ~np.isnan(flux)
+        valid_err = ~np.isnan(flux_err)
 
-        mjd_round = np.round(mjd).astype(int) 
-        unique_mjd = np.unique(mjd_round)
-        #Sum flux per unique mjd
-        flux_sum = np.bincount(mjd_round, weights=flux)
-        flux_count = np.bincount(mjd_round)
-        flux_avg = flux_sum[unique_mjd] / flux_count[unique_mjd]
-        # the same for err
-        flux_err_sum = np.bincount(mjd_round, weights=flux_err)
-        flux_err_avg = flux_err_sum[unique_mjd] / flux_count[unique_mjd]
-        
-        mjd_avg = unique_mjd
+        flux_sum = np.bincount(inv[valid_flux], weights=flux[valid_flux])
+        flux_count = np.bincount(inv[valid_flux])
+        flux_avg = flux_sum / flux_count
+
+        flux_err_sum = np.bincount(inv[valid_err], weights=flux_err[valid_err])
+        flux_err_count = np.bincount(inv[valid_err])
+        flux_err_avg = flux_err_sum / flux_err_count
+
+        mjd_sum = np.bincount(inv[valid_flux], weights=mjd[valid_flux])
+        mjd_avg = mjd_sum / flux_count
+        mjd_avg = np.around(mjd_avg,decimals=0).astype(float)
 
         # mask negative flux below low bound
-        valid = flux_avg > low_bound
-        flux_avg = flux_avg[valid]
-        flux_err_avg = flux_err_avg[valid]
-        mjd_avg = mjd_avg[valid]
-
+        valid_mask = flux_avg > low_bound
+        flux_avg = flux_avg[valid_mask]
+        flux_err_avg = flux_err_avg[valid_mask]
+        mjd_avg = mjd_avg[valid_mask]
         # check minimum number of points per filter
         if len(flux_avg) >= min_data_points:
 
@@ -533,17 +536,17 @@ def get_sigmoid_features_dev_fast(data_all: pd.DataFrame, ewma_window=3,
                 # compute the derivative
                 rising_c = get_ewma_derivative(pd.Series(flux_avg), ewma_window)
             elif rising_criteria == 'diff':
-                # calculate the diff with np (vectorized)
-                rising_c = np.diff(flux_avg,prepend=flux_avg[0])
-                      
-            # mask data with negative derivative
-            mask_rising = rising_c >= 0 
-            flux_rising = flux_avg[mask_rising]
-            flux_err_rising = flux_err_avg[mask_rising]
-            mjd_rising = mjd_avg[mask_rising]
+                # calculate the diff flux_avg with np (vectorized)
+                rising_c = np.diff(flux_avg,prepend=np.nan)
+
+            # mask data with negative part
+            rising_c = np.asarray(rising_c)
+            mask = ~ (rising_c < 0)
+            flux_rising = flux_avg[mask]
+            flux_err_rising = flux_err_avg[mask]
+            mjd_rising = mjd_avg[mask]
             # at least three points (needed for the sigmoid fit) and all points on the rise
             if(len(flux_rising) >= min_rising_points) and len(flux_rising) == len(flux_avg):
-
                 # compute signal to noise ratio
                 snratio[i] = get_sn_ratio(flux_rising,flux_err_rising)
 
@@ -575,6 +578,7 @@ def get_sigmoid_features_dev_fast(data_all: pd.DataFrame, ewma_window=3,
         a['g'], b['g'], c['g'], snratio['g'], mse['g'], nrise['g'],
         a['r'], b['r'], c['r'], snratio['r'], mse['r'], nrise['r']
     ]
+
 
 def main():
     return None

--- a/actsnfink/classifier_sigmoid.py
+++ b/actsnfink/classifier_sigmoid.py
@@ -22,7 +22,7 @@ from actsnfink.sigmoid import fit_sigmoid
 from actsnfink.sigmoid import delta_t
 from actsnfink.sigmoid import compute_mse
 from actsnfink.sigmoid import fsigmoid
-from line_profile import profile
+from line_profiler import profile
 
 __all__ = ['filter_data', 'mask_negative_data', 'get_fake_df', 'get_fake_fit_parameters',
           'get_fake_results', 'get_ewma_derivative', 'get_sn_ratio', 'get_predicted_flux',

--- a/actsnfink/profiling/README.md
+++ b/actsnfink/profiling/README.md
@@ -1,0 +1,66 @@
+# Profiling module 
+This directory contains a script to profile the performance of some functions. 
+
+## Requirements 
+
+Install the profoling tool:
+```
+source venv/bin/activate
+pip install line-profiler # Or pip install -r requirements.txt
+```
+
+## Running the profiler
+Run (and display) the profiling script with:
+```
+kernprof -l -v profile.py 
+```
+
+This will show the execution time for each line of the profiled functions : 
+
+```python
+File: ../fink_sn_activelearning/actsnfink/classifier_sigmoid.py
+Function: get_sigmoid_features_dev at line 345
+
+Line #      Hits         Time  Per Hit   % Time  Line Contents
+==============================================================
+   345                                           @profile
+   346                                           def get_sigmoid_features_dev(data_all: pd.DataFrame, ewma_window=3, 
+   347                                                                        min_rising_points=2, min_data_points=4,
+   348                                                                        rising_criteria='ewma'):
+   349                                               """Compute the features needed for the Random Forest classification based
+   350                                               on the sigmoid model.
+   ...
+   373                                           
+   374                                               """
+   375                                               # lower bound on flux
+   376         1          0.9      0.9      0.0      low_bound = -10
+   377                                           
+   378         1          0.5      0.5      0.0      list_filters = ['g', 'r']
+   379                                           
+   380                                               # features for different filters
+   381         1          0.7      0.7      0.0      a = {}
+   382         1          0.4      0.4      0.0      b = {}
+   383         1          0.2      0.2      0.0      c = {}
+   384         1          0.5      0.5      0.0      snratio = {}
+   385         1          0.3      0.3      0.0      mse = {}
+   386         1          0.2      0.2      0.0      nrise = {}
+   387                                           
+   388         3          1.8      0.6      0.0      for i in list_filters:
+   389                                                   # select filter
+   390         2       4196.6   2098.3     29.3          data_tmp = filter_data(data_all[columns_to_keep], i)
+   391                                                   # average over intraday data points
+   392         2       8208.4   4104.2     57.3          data_tmp_avg = average_intraday_data(data_tmp)
+   393                                                   # mask negative flux below low bound
+   394         2       1769.4    884.7     12.3          data_mjd = mask_negative_data(data_tmp_avg, low_bound)
+```
+
+What matters first is the column `% Time` which indicates the percentage of time
+spent per call. In this example above, 57.3 % is spent in calling ` average_intraday_data(data_tmp)`
+which would be the target to optimize if we want to improve the performances.
+
+Another important column is `Hits`, that is the number of time an instruction has been done.
+In this example, we  checked the loop condition 3 times. 
+
+
+## TODO: 
+Perform profiling (or not) for the other functions of the **actsnfink** module in the **profile.py** script, with the aim of finding bottlenecks and optimizations.

--- a/actsnfink/profiling/README.md
+++ b/actsnfink/profiling/README.md
@@ -6,13 +6,16 @@ This directory contains a script to profile the performance of some functions.
 Install the profoling tool:
 ```
 source venv/bin/activate
-pip install line-profiler # Or pip install -r requirements.txt
+pip install -r requirements.txt
+pip install . # to install package actsnfink
+
 ```
 
 ## Running the profiler
 Run (and display) the profiling script with:
 ```
-kernprof -l -v profile.py 
+
+kernprof -l -v actsnfink/profiling/profile.py 
 ```
 
 This will show the execution time for each line of the profiled functions : 

--- a/actsnfink/profiling/profile.py
+++ b/actsnfink/profiling/profile.py
@@ -1,0 +1,15 @@
+import pandas as pd 
+import numpy as np
+import random 
+from actsnfink.classifier_sigmoid import get_fake_df,get_sigmoid_features_dev,get_sigmoid_features_dev_fast
+
+df = get_fake_df('g') 
+
+print("Original version")
+l1 = get_sigmoid_features_dev(df)
+print("Optimised version")
+l2 = get_sigmoid_features_dev_fast(df)
+
+# Just for testing 
+assert l1==l2,"Not the same results! "
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ numpy>=1.21.6
 actsnclass>=1.2
 scipy>=1.7.3
 scikit-learn>=1.0.2
+line-profiler


### PR DESCRIPTION
# Fast implementation for get_sigmoid_features_dev 

## Context 
I am working on optimizing Fink's Spark tasks, and optimizing these tasks also involves optimizing the scientific modules.
While I profiling  the **rfscore_sigmoid_full** processor of the scientific module Early_SN_Ia (ztf/random_forest_snia), I observed that a significant fraction of **"97% TIME"** of the runtime is spent inside **get_sigmoid_features_dev** . And this is as follows:

```python
Total time: 117.25 seconds 
File: /opt/fink-broker/miniconda/lib/python3.9/site-packages/fink_science/ztf/random_forest_snia/processor.py
Function: rfscore_sigmoid_full at line 77
Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
    77                                           @pandas_udf(DoubleType(), PandasUDFType.SCALAR)
    78                                           @profile
    79                                           def rfscore_sigmoid_full(
    80                                               jd,
    81                                               fid,
    82                                               magpsf,
    83                                               sigmapsf,
    84                                               cdsxmatch,
    85                                               ndethist,
    86                                               min_rising_points=None,
    87                                               min_data_points=None,
    88                                               rising_criteria=None,
    89                                               model=None,
    90                                           ) -> pd.Series 
    ...
    205         1          2.3      2.3      0.0      if min_rising_points is None:
   206         1        372.7    372.7      0.0          min_rising_points = pd.Series([2])
   207         1          0.9      0.9      0.0      if min_data_points is None:
   208         1        211.4    211.4      0.0          min_data_points = pd.Series([4])
   209         1          0.7      0.7      0.0      if rising_criteria is None:
   210         1        219.3    219.3      0.0          rising_criteria = pd.Series(["ewma"])
   211         1    1189433.7    1e+06      1.0      mask = apply_selection_cuts_ztf(magpsf, ndethist, cdsxmatch)
   212                                           
   213         1        729.1    729.1      0.0      if len(jd[mask]) == 0:
   214                                                   return pd.Series(np.zeros(len(jd), dtype=float))
   215                                           
   216         1        262.3    262.3      0.0      candid = pd.Series(range(len(jd)))
   217         1     243795.3 243795.3      0.2      pdf = format_data_as_snana(jd, magpsf, sigmapsf, fid, candid, mask)
   218                                           
   219                                               # Load pre-trained model `clf`
   220         1          1.5      1.5      0.0      if model is not None:
   221                                                   clf = load_scikit_model(model.to_numpy()[0])
   222                                               else:
   223         1         75.1     75.1      0.0          curdir = os.path.dirname(os.path.abspath(__file__))
   224         1          1.2      1.2      0.0          model = curdir + "/data/models/default-model_sigmoid.obj"
   225         1      81880.9  81880.9      0.1          clf = load_scikit_model(model)
   226                                           
   227         1          0.7      0.7      0.0      test_features = []
   228         1          0.6      0.6      0.0      flag = []
   229                                           
   230      6864     357792.8     52.1      0.3      for _, pdf_sub in pdf.groupby("SNID"):
   231     13726  114512892.9   8342.8     97.7          features = get_sigmoid_features_dev(
   232      6863       4335.3      0.6      0.0              pdf_sub,
   233      6863      98653.0     14.4      0.1              min_rising_points=min_rising_points.to_numpy()[0],
   234      6863      45542.8      6.6      0.0              min_data_points=min_data_points.to_numpy()[0],
   235      6863      48592.9      7.1      0.0              rising_criteria=rising_criteria.to_numpy()[0],
   236                                                   )
   ....
   255                                           
   256         1        317.8    317.8      0.0      return pd.Series(to_return)
```

## Proposed solution 
I implemented an alternative version which uses NumPy vectorization, this new feature that I named : **get_sigmoid_features_dev_fast**.

The profiling of **get_sigmoid_features_dev** (original implementation)  here it is: 
```python
Total time: 0.0123061 s
File: ../fink_sn_activelearning/actsnfink/classifier_sigmoid.py
Function: get_sigmoid_features_dev at line 345

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   345                                           @profile
   346                                           def get_sigmoid_features_dev(data_all: pd.DataFrame, ewma_window=3, 
   347                                                                        min_rising_points=2, min_data_points=4,
   348                                                                        rising_criteria='ewma'):
   349                                               """Compute the features needed for the Random Forest classification based
   350                                               on the sigmoid model.
   351                                           
   352                                               Parameters
   353                                               ----------
   354                                               data_all: pd.DataFrame
   355                                                   Pandas DataFrame with at least ['MJD', 'FLT', 'FLUXCAL', 'FLUXCALERR']
   356                                                   as columns.
   357                                               ewma_window: int (optional)
   358                                                   Width of the ewma window. Default is 3.
   359                                               min_rising_points: int (optional)
   360                                                   Minimum number of rising points. Default is 2.
   361                                               min_data_points: int (optional)
   362                                                   Minimum number of data points. Default is 4.
   363                                               rising_criteria: str (optional)
   364                                                   Criteria for defining rising points. Options are 'diff' or 'ewma'.
   365                                                   Default is 'ewma'.
   366                                           
   367                                               Returns
   368                                               -------
   369                                               out: list of floats
   370                                                   List of features, ordered by filter bands:
   371                                                   [a['g'], b['g'], c['g'], snratio['g'], mse['g'], nrise['g'],
   372                                                    a['r'], b['r'], c['r'], snratio['r'], mse['r'], nrise['r']]
   373                                           
   374                                               """
   375                                               # lower bound on flux
   376         1          0.6      0.6      0.0      low_bound = -10
   377                                           
   378         1          0.5      0.5      0.0      list_filters = ['g', 'r']
   379                                           
   380                                               # features for different filters
   381         1          0.4      0.4      0.0      a = {}
   382         1          0.5      0.5      0.0      b = {}
   383         1          0.4      0.4      0.0      c = {}
   384         1          0.8      0.8      0.0      snratio = {}
   385         1          0.2      0.2      0.0      mse = {}
   386         1          0.5      0.5      0.0      nrise = {}
   387                                           
   388         3          1.9      0.6      0.0      for i in list_filters:
   389                                                   # select filter
   390         2       3807.0   1903.5     30.9          data_tmp = filter_data(data_all[columns_to_keep], i)
   391                                                   # average over intraday data points
   392         2       6798.5   3399.3     55.2          data_tmp_avg = average_intraday_data(data_tmp)
   393                                                   # mask negative flux below low bound
   394         2       1551.8    775.9     12.6          data_mjd = mask_negative_data(data_tmp_avg, low_bound)
   395                                           
   396                                                   # check minimum number of points per filter
   397         2        128.5     64.2      1.0          if len(data_mjd['FLUXCAL'].values) >= min_data_points:
   398                                           
   399                                                       if rising_criteria == 'ewma':
   ....
   441                                                   else:
   442                                                       # if data points not enough
   443         2          2.0      1.0      0.0              [a[i], b[i], c[i], snratio[i], mse[i], nrise[i]] = \
   444         2          9.7      4.8      0.1                  get_fake_results(i)
   445                                           
   446         1          1.8      1.8      0.0      return [
   447         1          0.5      0.5      0.0          a['g'], b['g'], c['g'], snratio['g'], mse['g'], nrise['g'],
   448         1          0.4      0.4      0.0          a['r'], b['r'], c['r'], snratio['r'], mse['r'], nrise['r']
   449                                               ]
```
It's clear that if we want to improve performance, we need to focus on optimizing : 
- **average_intraday_data(data_tmp)** which represente 55% of runtime 
- and also **filter_data(data_all[columns_to_keep], i)** (30% of runtime) & **mask** (12% of runtime)

So, the main changes introduced in the fast version are : 
- avoid deepcopy of dataframes 
- converts the DataFrame columns to Numpy arrays 
- use boolean masking instead of repeated dataframe filtering 
- vectorize intraday averaging using np.bincount (https://numpy.org/devdocs/reference/generated/numpy.bincount.html)

## Results 
NB : Profiling with :  df = classifier_sigmoid.get_fake_df()

Initial tests show that both implementations return the same results and the fast implementation **get_sigmoid_features_dev_fast**  **reduce the runtime from 0.012 s to 0.0009 s (speed_up  x13)**. 

as can be seen here:

```python
Total time: 0.000952445 s
File: ../fink_sn_activelearning/actsnfink/classifier_sigmoid.py
Function: get_sigmoid_features_dev2 at line 451

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   451                                           @profile
   452                                           def get_sigmoid_features_dev_fast(data_all: pd.DataFrame, ewma_window=3, 
   453                                                                        min_rising_points=2, min_data_points=4,
   454                                                                        rising_criteria='ewma'):
   455                                               """Compute the features needed for the Random Forest classification based
   456                                               on the sigmoid model.
   457                                           
   458                                               Parameters
   459                                               ----------
   460                                               data_all: pd.DataFrame
   461                                                   Pandas DataFrame with at least ['MJD', 'FLT', 'FLUXCAL', 'FLUXCALERR']
   462                                                   as columns.
   463                                               ewma_window: int (optional)
   464                                                   Width of the ewma window. Default is 3.
   465                                               min_rising_points: int (optional)
   466                                                   Minimum number of rising points. Default is 2.
   467                                               min_data_points: int (optional)
   468                                                   Minimum number of data points. Default is 4.
   469                                               rising_criteria: str (optional)
   470                                                   Criteria for defining rising points. Options are 'diff' or 'ewma'.
   471                                                   Default is 'ewma'.
   472                                           
   473                                               Returns
   474                                               -------
   475                                               out: list of floats
   476                                                   List of features, ordered by filter bands:
   477                                                   [a['g'], b['g'], c['g'], snratio['g'], mse['g'], nrise['g'],
   478                                                    a['r'], b['r'], c['r'], snratio['r'], mse['r'], nrise['r']]
   479                                           
   480                                               """
   481                                               # lower bound on flux
   482         1          0.6      0.6      0.1      low_bound = -10
   483                                           
   484         1          0.3      0.3      0.0      list_filters = ['g', 'r']
   485                                           
   486                                               # features for different filters
   487         1          0.2      0.2      0.0      a = {}
   488         1          0.7      0.7      0.1      b = {}
   489         1          0.2      0.2      0.0      c = {}
   490         1          0.2      0.2      0.0      snratio = {}
   491         1          0.2      0.2      0.0      mse = {}
   492         1          0.2      0.2      0.0      nrise = {}
   493                                           
   494                                               # avoid deepcopy (slow), replace it by numpy+mask 
   495                                               # extract columns on format numpy
   496         1        812.2    812.2     85.3      data_np = data_all[columns_to_keep].to_numpy()
   497         1          4.0      4.0      0.4      mjd_all, flt_all, flux_all, flux_err_all = data_np[:,0:4].T
   498         1          1.6      1.6      0.2      mjd_all = mjd_all.astype(float)
   499         1          0.6      0.6      0.1      flux_all = flux_all.astype(float)
   500         1          0.5      0.5      0.1      flux_err_all = flux_err_all.astype(float)
   501         3          1.1      0.4      0.1      for i in list_filters:
   502                                                   # add mask to filter
   503         2          6.7      3.3      0.7          mask_flt = flt_all == i
   504         2          2.0      1.0      0.2          mjd = mjd_all[mask_flt]
   505         2          0.9      0.4      0.1          flux = flux_all[mask_flt]
   506         2          0.9      0.5      0.1          flux_err = flux_err_all[mask_flt]
   507                                           
   508                                                   # vectorised average over intraday data points 
   509                                           
   510         2         15.8      7.9      1.7          mjd_round = np.round(mjd).astype(int) 
   511         2         65.3     32.7      6.9          unique_mjd = np.unique(mjd_round)
   512                                           
   513                                                   #Sum flux per unique mjd
   514         2          3.8      1.9      0.4          flux_sum = np.bincount(mjd_round, weights=flux)
   515         2          2.7      1.3      0.3          flux_count = np.bincount(mjd_round)
   516         2          8.0      4.0      0.8          flux_avg = flux_sum[unique_mjd] / flux_count[unique_mjd]
   517                                                   
   518                                                   # the same for err
   519         2          2.5      1.2      0.3          flux_err_sum = np.bincount(mjd_round, weights=flux_err)
   520         2          3.3      1.7      0.4          flux_err_avg = flux_err_sum[unique_mjd] / flux_count[unique_mjd]
   521                                                   
   522         2          0.6      0.3      0.1          mjd_avg = unique_mjd
   523                                           
   524                                                   # mask negative flux below low bound
   525         2          3.8      1.9      0.4          valid = flux_avg > low_bound
   526         2          1.5      0.7      0.2          flux_avg = flux_avg[valid]
   527         2          0.9      0.4      0.1          flux_err_avg = flux_err_avg[valid]
   528         2          0.8      0.4      0.1          mjd_avg = mjd_avg[valid]
   529                                           
   530                                                   # check minimum number of points per filter
   531         2          0.9      0.4      0.1          if len(flux_avg) >= min_data_points:
    ...
   572         2          1.5      0.7      0.2              [a[i], b[i], c[i], snratio[i], mse[i], nrise[i]] = \
   573         2          5.1      2.5      0.5                  get_fake_results(i)
   574                                           
   575         1          2.1      2.1      0.2      return [
   576         1          0.4      0.4      0.0          a['g'], b['g'], c['g'], snratio['g'], mse['g'], nrise['g'],
   577         1          0.4      0.4      0.0          a['r'], b['r'], c['r'], snratio['r'], mse['r'], nrise['r']
   578                                               ]

```

Thanks !
Massinissa 